### PR TITLE
Added missed minter check

### DIFF
--- a/contracts/ERC1155NonFungibleMintable.sol
+++ b/contracts/ERC1155NonFungibleMintable.sol
@@ -62,7 +62,7 @@ contract ERC1155NonFungibleMintable is ERC1155NonFungible {
     }
 
     function mintFungible(uint256 _type, address[] _to, uint256[] _values)
-    external  {
+    external minterOnly(_type) {
 
         require(isFungible(_type));
 


### PR DESCRIPTION
Only minter of `_type` should be able to mint Fungible (same as for Non Fungible)