### PR TITLE
Relax pragma to ^0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ www.enjincoin.io
 This is a work-in-progress implementation of ERC-1155 based on the discussions in the [EIP-1155 issue thread](https://github.com/ethereum/EIPs/issues/1155).
 
 Requirements:
-* Solidity 0.5.3
+* Solidity 0.5
 
 ## Setup
 Run `npm install` in the root directory.

--- a/contracts/Address.sol
+++ b/contracts/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/contracts/ERC1155.sol
+++ b/contracts/ERC1155.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./SafeMath.sol";
 import "./Address.sol";

--- a/contracts/ERC1155AllowanceWrapper.sol
+++ b/contracts/ERC1155AllowanceWrapper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./IERC1155.sol";
 import "./ERC165.sol";

--- a/contracts/ERC1155Mintable.sol
+++ b/contracts/ERC1155Mintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./ERC1155.sol";
 

--- a/contracts/ERC1155MixedFungible.sol
+++ b/contracts/ERC1155MixedFungible.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./ERC1155.sol";
 

--- a/contracts/ERC1155MixedFungibleMintable.sol
+++ b/contracts/ERC1155MixedFungibleMintable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./ERC1155MixedFungible.sol";
 

--- a/contracts/ERC1155MockReceiver.sol
+++ b/contracts/ERC1155MockReceiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 // Contract to test safe transfer behavior.
 contract ERC1155MockReceiver {

--- a/contracts/ERC165.sol
+++ b/contracts/ERC165.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 
 /**

--- a/contracts/IERC1155.sol
+++ b/contracts/IERC1155.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 import "./ERC165.sol";
 

--- a/contracts/IERC1155Metadata.sol
+++ b/contracts/IERC1155Metadata.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 interface IERC1155Metadata_URI {
     /**

--- a/contracts/IERC1155TokenReceiver.sol
+++ b/contracts/IERC1155TokenReceiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 interface IERC1155TokenReceiver {
     /**

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.4;
+pragma solidity ^0.5.0;
 
 
 /**


### PR DESCRIPTION
This will allow projects targetting earlier Solidity 0.5.x versions to use this repo