### PR TITLE
Fixed NFI balance override in balanceOfBatch

### DIFF
--- a/contracts/ERC1155MixedFungible.sol
+++ b/contracts/ERC1155MixedFungible.sol
@@ -117,8 +117,9 @@ contract ERC1155MixedFungible is ERC1155 {
             uint256 id = _ids[i];
             if (isNonFungibleItem(id)) {
                 balances_[i] = nfOwners[id] == _owners[i] ? 1 : 0;
+            } else {
+            	balances_[i] = balances[id][_owners[i]];
             }
-            balances_[i] = balances[id][_owners[i]];
         }
 
         return balances_;


### PR DESCRIPTION
NFI balance was always 0 when calling `balanceOfBatch`